### PR TITLE
NGMWN-1878 apply a x100 to latest percentile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - created a unit test that shows how mediation changes values while demonstrating forcing BelowLand.
 - ensure given samples are sorted by date rather than assuming now that it is an independent service.
 - converted Elevation value to BigDecimal
-
+- Latest Percentile is now recored at %100 based vs a decimal value between 0 and 1.
 
 ## [0.2.0] - 2018-08-30?
 ### Added

--- a/src/main/java/gov/usgs/ngwmn/logic/WaterLevelStatistics.java
+++ b/src/main/java/gov/usgs/ngwmn/logic/WaterLevelStatistics.java
@@ -20,6 +20,7 @@ import gov.usgs.ngwmn.model.WLSample;
 import gov.usgs.wma.statistics.app.Properties;
 import gov.usgs.wma.statistics.logic.MonthlyStatistics;
 import gov.usgs.wma.statistics.logic.OverallStatistics;
+import gov.usgs.wma.statistics.logic.SigFigMathUtil;
 import gov.usgs.wma.statistics.logic.StatisticsCalculator;
 import gov.usgs.wma.statistics.model.JsonData;
 import gov.usgs.wma.statistics.model.JsonDataBuilder;
@@ -33,6 +34,11 @@ public class WaterLevelStatistics extends StatisticsCalculator<WLSample> {
 	 */
 	protected static final BigDecimal Days406 = new BigDecimal("406");
 
+	/**
+	 * The number 100 used to make a decimal percentile into a %100 based value.
+	 * It has many decimal places so that this number preserves the precision of the original value.
+	 */
+	protected static final BigDecimal NUM_100 = new BigDecimal("100.000000");
 
 	// Package level access for unit testing
 	MonthlyStatistics<WLSample> monthlyStats;
@@ -160,7 +166,8 @@ public class WaterLevelStatistics extends StatisticsCalculator<WLSample> {
 		replaceLatestSample(normalizeMutlipleYearlyValues, latestSample);
 		// get the percentile of the latest sample
 		BigDecimal latestPercentile = percentileOfValue(normalizeMutlipleYearlyValues, latestSample, Value::valueOf);
-		builder.latestPercentile(latestPercentile.toString());
+		latestPercentile = SigFigMathUtil.sigFigMultiply(latestPercentile, NUM_100.setScale(latestPercentile.scale()));
+		builder.latestPercentile(latestPercentile.toPlainString());
 	}
 
 	protected void replaceLatestSample(List<WLSample> normalizeMutlipleYearlyValues, WLSample latestSample) {

--- a/src/main/java/gov/usgs/wma/statistics/model/JsonOverall.java
+++ b/src/main/java/gov/usgs/wma/statistics/model/JsonOverall.java
@@ -7,7 +7,7 @@ import gov.usgs.ngwmn.model.MediationType;
 /**
  * the JSON will look something like this
  * {
- *	"LATEST_PCTILE": "0.31250"
+ *	"LATEST_PCTILE": "31.250"
  *	"LATEST_VALUE": "11.000",
  *	"MAX_VALUE": "1.000",
  *	"MEDIAN": "1.500",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=8777
-logging.level.gov.usgs=INFO
+logging.level.gov=DEBUG
+logging.level.org.springframework==DEBUG
 
 spring.servlet.multipart.max-request-size=20mb
 

--- a/src/test/java/gov/usgs/ngwmn/logic/WaterLevelStatisticsTest.java
+++ b/src/test/java/gov/usgs/ngwmn/logic/WaterLevelStatisticsTest.java
@@ -285,7 +285,7 @@ public class WaterLevelStatisticsTest {
 				
 		stats.overallLatestPercentile(sortedByDate);
 		String percentile = builder.get(JsonDataBuilder.LATEST_PCTILE);
-		assertEquals("0.750", percentile);
+		assertEquals("75.0", percentile);
 	}
 	@Test
 	public void test_valueOfPercentile_ascending_P75() {
@@ -340,7 +340,7 @@ public class WaterLevelStatisticsTest {
 				
 		stats.overallLatestPercentile(sortedByDate);
 		String percentile = builder.get(JsonDataBuilder.LATEST_PCTILE);
-		assertEquals("0.250", percentile);
+		assertEquals("25.0", percentile);
 	}
 	
 	@Test
@@ -566,7 +566,7 @@ public class WaterLevelStatisticsTest {
 		assertEquals("Expect count to be 7", 7, overall.sampleCount);
 		assertEquals("Expect median to be mid.value", mid.value.toString(), overall.valueMedian);
 		assertEquals( mid1.getValue().toString(), overall.latestValue);
-		assertEquals( "0.38", overall.latestPercentile);
+		assertEquals( "38", overall.latestPercentile);
 	}
 
 
@@ -758,11 +758,11 @@ public class WaterLevelStatisticsTest {
 		assertNotNull("overall should not be null", overall);
 		assertNotNull("monthly should not be null", monthly);
 
-		assertEquals("Expect MIN_VALUE to be ", "100.0",     overall.valueMin);
-		assertEquals("Expect MAX_VALUE to be ",   "1.0",     overall.valueMax);
-		assertEquals("Expect MEDIAN to be ",      "1.0",     overall.valueMedian);
-		assertEquals("Expect LATEST_VALUE to be ", "100.0",  overall.latestValue);
-		assertEquals("Expect LATEST_PCTILE to be ", "0",     overall.latestPercentile);
+		assertEquals("Expect MIN_VALUE to be ",    "100.0", overall.valueMin);
+		assertEquals("Expect MAX_VALUE to be ",      "1.0", overall.valueMax);
+		assertEquals("Expect MEDIAN to be ",         "1.0", overall.valueMedian);
+		assertEquals("Expect LATEST_VALUE to be ", "100.0", overall.latestValue);
+		assertEquals("Expect LATEST_PCTILE to be ",  "0", overall.latestPercentile);
 
 		assertEquals("Expect percentile to be 80.2", "80.2", monthly.get("5").percentiles.get(P10));
 		assertEquals("Expect most percentile to be ", "1.0", monthly.get("5").percentiles.get(P25));
@@ -909,7 +909,7 @@ public class WaterLevelStatisticsTest {
 		assertFalse(valueOrder.contains(provisional));
 
 		assertEquals("7.98",  builder.get(MEDIAN));
-		assertEquals("1", builder.get(LATEST_PCTILE));
+		assertEquals("100", builder.get(LATEST_PCTILE));
 	}
 	@Test
 	public void testMostRecentProvistional_overallStats_BelowLand() {
@@ -949,7 +949,7 @@ public class WaterLevelStatisticsTest {
 		assertTrue(valueOrder.contains(notProvisional));
 
 		assertEquals("7.98", builder.get(MEDIAN));
-		assertEquals("1", builder.get(LATEST_PCTILE));
+		assertEquals("100", builder.get(LATEST_PCTILE));
 	}
 	@Test
 	public void testMostRecentProvistionalNONE_overallStats_BelowLand() {

--- a/src/test/java/gov/usgs/ngwmn/logic/WaterLevelXmlTest.java
+++ b/src/test/java/gov/usgs/ngwmn/logic/WaterLevelXmlTest.java
@@ -103,7 +103,7 @@ public class WaterLevelXmlTest {
 		
 		// EXPECT
 		expected.put("latestValue", "200.390000");
-		expected.put("latestPercentile", "0.250000000");
+		expected.put("latestPercentile", "25.0000000");
 		expected.put("valueMin", "209.790000");
 		expected.put("valueMax", "180.620000");
 		
@@ -121,6 +121,7 @@ public class WaterLevelXmlTest {
 		setup("MBMG","73642", ZERO,"BLS");
 		
 		// EXPECT
+		// until MBMG has appropriate sigfigs, this is the precision we expect.
 		expected.put("latestValue", "146.600000");
 		expected.put("latestPercentile", "0");
 		expected.put("valueMin", "150.790000");
@@ -141,7 +142,7 @@ public class WaterLevelXmlTest {
 		
 		// EXPECT
 		expected.put("latestValue", "17.960000");
-		expected.put("latestPercentile", "1");
+		expected.put("latestPercentile", "100");
 		expected.put("valueMin", "19.760000");
 		expected.put("valueMax", "10.380000");
 		
@@ -160,7 +161,7 @@ public class WaterLevelXmlTest {
 		
 		// EXPECT
 		expected.put("latestValue", "98.29");
-		expected.put("latestPercentile", "1");
+		expected.put("latestPercentile", "100");
 		expected.put("valueMin", "115.97");
 		expected.put("valueMax", "98.29");
 		
@@ -177,7 +178,7 @@ public class WaterLevelXmlTest {
 		
 		// EXPECT
 		expected.put("latestValue", "4.99");
-		expected.put("latestPercentile", "0.786");
+		expected.put("latestPercentile", "78.6");
 		expected.put("valueMin", "12.66");
 		expected.put("valueMax", "1.06");
 		
@@ -196,7 +197,7 @@ public class WaterLevelXmlTest {
 		
 		// EXPECT
 		expected.put("latestValue", "49.80");
-		expected.put("latestPercentile", "0.6000");
+		expected.put("latestPercentile", "60.00");
 		expected.put("valueMin", "58.82");
 		expected.put("valueMax", "45.15");
 		
@@ -226,7 +227,7 @@ public class WaterLevelXmlTest {
 		
 		// EXPECT
 		expected.put("latestValue", "5.48");
-		expected.put("latestPercentile", "0.357");
+		expected.put("latestPercentile", "35.7");
 		expected.put("valueMin", "-16.15");
 		expected.put("valueMax",  "10.09");
 //		expected.put("valueMax",  "19.93"); // this is a BL measurement with a AD site
@@ -271,7 +272,7 @@ public class WaterLevelXmlTest {
 		JsonData json = service.calculate(builder, data, mediation, includeMedians, percentiles);
 		
 		// EXPECT
-		expected.put("latestPercentile", "0.36");
+		expected.put("latestPercentile", "36");
 		expected.put("latestValue", new BigDecimal("-5.48").add(altVal).round(precisionRound2).toPlainString());
 		expected.put("valueMin",    new BigDecimal("16.15").add(altVal).round(precisionRound3).toPlainString());
 		expected.put("valueMax",    new BigDecimal("-10.09").add(altVal).round(precisionRound2).toPlainString());


### PR DESCRIPTION
the story is to make the percetile %100 based rather than the original decimal

Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
NGMWN-1878 apply a x100 to latest percentile
Description
-----------
Originally, the latest percentile was recorded as decimal between 0 and 1.
All other percentiles are reported as %100 based. The unifies that practice.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
