### PR TITLE
NGWMN-1899 fix percentile typo and change nulls to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Updated: bypass latest percentile for months with few samples
+- Changed latest percentile to be an empty string when the month has too few values rather than null.
+- Fixed typo in "percentiles" string to "percentiles"
+
+### Notes
+- Releases 1.0.2 through 1.0.6 are all pipeline release build testing
 
 ## [1.0.1]
 ### Changed

--- a/src/main/java/gov/usgs/ngwmn/logic/WaterLevelStatistics.java
+++ b/src/main/java/gov/usgs/ngwmn/logic/WaterLevelStatistics.java
@@ -178,8 +178,8 @@ public class WaterLevelStatistics extends StatisticsCalculator<WLSample> {
 		List<WLSample> normalizeMutlipleYearlyValues = 
 				monthlyStats.medianMonthlyValues(monthSamples,  monthlyStats.sortFunctionByQualifier());
 		if (normalizeMutlipleYearlyValues.size()<9) {
-			// do not calculate latest percentile for months with low data
-			builder.latestPercentile(null);
+			// NGMWN-1896 do not calculate latest percentile for months with low data
+			builder.latestPercentile("");
 			return;
 		}
 		// the most recent must now be added into the collection and replace of the year-month it represents

--- a/src/main/java/gov/usgs/wma/statistics/model/JsonMonthly.java
+++ b/src/main/java/gov/usgs/wma/statistics/model/JsonMonthly.java
@@ -25,7 +25,7 @@ public class JsonMonthly extends JsonStats {
 	 * the result will likely be 0.10000000000000001 further confusing the accuracy of the 
 	 * measured value.
 	 */
-	@JsonProperty("PERCETILES")
+	@JsonProperty("PERCENTILES")
 	public final Map<String, String> percentiles;
 
 	public JsonMonthly(String recordYears, int sampleCount, Map<String, String> percentiles) {

--- a/src/test/java/gov/usgs/ngwmn/logic/WaterLevelXmlTest.java
+++ b/src/test/java/gov/usgs/ngwmn/logic/WaterLevelXmlTest.java
@@ -123,7 +123,7 @@ public class WaterLevelXmlTest {
 		// EXPECT
 		// until MBMG has appropriate sigfigs, this is the precision we expect.
 		expected.put("latestValue", "146.600000");
-		expected.put("latestPercentile", null); // latest values is in month 10 with only 6 other years
+		expected.put("latestPercentile", ""); // latest values is in month 10 with only 6 other years
 		expected.put("valueMin", "150.790000");
 		expected.put("valueMax", "135.760000");
 		
@@ -306,7 +306,7 @@ public class WaterLevelXmlTest {
 		expected.put("valueMax",  "9.30"); // this is the max BL retained sample
 		expected.put("valueMin",  "19.93"); // this is the min BL retained sample
 		expected.put("latestValue", "11.47"); // this is the latest retained sample
-		expected.put("latestPercentile", null); // the latest value is for month 12 w/ only three other samples
+		expected.put("latestPercentile", ""); // the latest value is for month 12 w/ only three other samples
 		
 		// TEST
 		JsonData json = stats.calculate(spec, xmlReader);


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run (they pass in IDE and MVN but then after all tests pass mvn crashes)
- [x] Update the changelog appropriately

Title
-----------
Updated a spelling error in a string constant and changed null values to empty strings

Description
-----------
Percetiles typo change to percentiles.
A change that missed commit where null values were changed to empty string is included here.


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
