### PR TITLE
Allow the stats service to interpret the enforceRecent option from the cache.

### DIFF
--- a/src/main/java/gov/usgs/ngwmn/logic/WaterLevelStatistics.java
+++ b/src/main/java/gov/usgs/ngwmn/logic/WaterLevelStatistics.java
@@ -19,6 +19,7 @@ import gov.usgs.ngwmn.model.PCode;
 import gov.usgs.ngwmn.model.Specifier;
 import gov.usgs.ngwmn.model.WLSample;
 import gov.usgs.wma.statistics.app.Properties;
+import gov.usgs.wma.statistics.app.SwaggerConfig;
 import gov.usgs.wma.statistics.logic.MonthlyStatistics;
 import gov.usgs.wma.statistics.logic.OverallStatistics;
 import gov.usgs.wma.statistics.logic.SigFigMathUtil;
@@ -33,7 +34,7 @@ public class WaterLevelStatistics extends StatisticsCalculator<WLSample> {
 	 * This is the agreed upon days window for a recent value. It is computed from
 	 * 1 year + 1 month + 1.5 weeks or 365 + 30 + 7 + 4 because of how samples are taken and eventually entered.
 	 */
-	protected static final BigDecimal Days406 = new BigDecimal("406");
+	protected static final BigDecimal Days406 = new BigDecimal(SwaggerConfig.Days406);
 
 	/**
 	 * The number 100 used to make a decimal percentile into a %100 based value.
@@ -44,10 +45,13 @@ public class WaterLevelStatistics extends StatisticsCalculator<WLSample> {
 	// Package level access for unit testing
 	MonthlyStatistics<WLSample> monthlyStats;
 	OverallStatistics<WLSample> overallStatistics;
+	boolean enforceRecent;
 	
 	
-	public WaterLevelStatistics(Properties env, JsonDataBuilder builder) {
+	public WaterLevelStatistics(Properties env, JsonDataBuilder builder, boolean enforceRecent) {
 		super(env, builder);
+		
+		this.enforceRecent = enforceRecent;
 		
 		monthlyStats = new WaterLevelMonthlyStats(env, builder);
 		
@@ -314,7 +318,7 @@ public class WaterLevelStatistics extends StatisticsCalculator<WLSample> {
 	 * @return
 	 */
 	protected boolean doesThisSiteQualifyForMonthlyStats(BigDecimal years, String recent, String today) {
-		return BigDecimal.TEN.compareTo(years) <= 0 && Days406.compareTo(daysDiff(today, recent)) >= 0;
+		return !enforceRecent || (BigDecimal.TEN.compareTo(years) <= 0 && Days406.compareTo(daysDiff(today, recent)) >= 0);
 	}
 
 	protected WLSample makeMedian(List<WLSample> samples) {

--- a/src/main/java/gov/usgs/wma/statistics/app/SwaggerConfig.java
+++ b/src/main/java/gov/usgs/wma/statistics/app/SwaggerConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import com.fasterxml.classmate.TypeResolver;
 
 import gov.usgs.wma.statistics.model.JsonData;
+import java.math.BigDecimal;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
@@ -42,6 +43,10 @@ public class SwaggerConfig {
 	public static final String StatsService_MEDIANS_DEFAULT      =BOOLEAN_FALSE;
 	public static final String StatsService_CALCULATE_MEDIANS    ="If true, returns the intermediate values used in the calculations. For monthly percentiles it is required that no month have more weight than any other. When a month has multiple values, the median is used. This feature returns these intermediate values. The defaule is " + StatsService_MEDIANS_DEFAULT;
 	
+	public static final String Days406 = "406";
+	public static final String StatsService_ENFORCE_RECENT_DEFAULT    =BOOLEAN_TRUE;
+	public static final String StatsService_CALCULATE_ENFORCE_RECENT  ="If true, the statistics will be calculated only if the most recent value is less than " + Days406 + " days old. The default value is " + StatsService_ENFORCE_RECENT_DEFAULT;
+
 	public static final String StatsService_PERCENTILES_DEFAULT  ="10,25,50,75,90";
 	public static final String StatsService_CALCULATE_PERCENTILES="A comma delimited list of percentiles like the default " + StatsService_PERCENTILES_DEFAULT;
 	

--- a/src/test/java/gov/usgs/ngwmn/logic/WaterLevelStatisticsTest.java
+++ b/src/test/java/gov/usgs/ngwmn/logic/WaterLevelStatisticsTest.java
@@ -50,6 +50,7 @@ public class WaterLevelStatisticsTest {
 	WaterLevelStatistics stats = null;
 	Specifier spec = new Specifier();
 	private JsonDataBuilder builder;
+	boolean enforceRecent;
 
 	private WLSample createSample(String time, String value) {
 		BigDecimal val = null;
@@ -108,9 +109,9 @@ public class WaterLevelStatisticsTest {
 	public void setup() {
 		env = new Properties().setEnvironment(spring);
 		builder = new JsonDataBuilder(env);
-		stats = new WaterLevelStatistics(env, builder);
+		enforceRecent = true;
+		stats = new WaterLevelStatistics(env, builder, enforceRecent);
 		spec = new Specifier("USGS", "Testing");
-
 	}
 
 	

--- a/src/test/java/gov/usgs/ngwmn/logic/WaterLevelXmlTest.java
+++ b/src/test/java/gov/usgs/ngwmn/logic/WaterLevelXmlTest.java
@@ -49,6 +49,7 @@ public class WaterLevelXmlTest {
 	JsonDataBuilder builder;
 	WaterLevelStatistics stats;
 	Elevation elevation;
+	boolean enforceRecent;
 	
 	Reader xmlReader;
 	Map<String,String> expected;
@@ -58,7 +59,8 @@ public class WaterLevelXmlTest {
 		spec     = new Specifier();
 		env      = new Properties().setEnvironment(spring);
 		builder  = new JsonDataBuilder(env);
-		stats    = new WaterLevelStatistics(env, builder);
+		enforceRecent = true;
+		stats    = new WaterLevelStatistics(env, builder, enforceRecent);
 		expected = new HashMap<>();
 	}
 
@@ -263,13 +265,14 @@ public class WaterLevelXmlTest {
 		
 		StatsService service  = new StatsService().setProperties(env);
 		String mediation      = MediationType.BelowLand.toString(); // override from AboveDatum 
+		String enforceRecentTrue = "true";
 		String percentiles    = StatsService_PERCENTILES_DEFAULT;
 		String includeMedians = StatsService_MEDIANS_DEFAULT;
 		String data           = samples.stream()           // the service receives its data from the web as text
 								.map(sample -> sample.toCSV())
 								.collect(Collectors.joining("\n"));
 		// TEST
-		JsonData json = service.calculate(builder, data, mediation, includeMedians, percentiles);
+		JsonData json = service.calculate(builder, data, mediation, includeMedians, enforceRecentTrue, percentiles);
 		
 		// EXPECT
 		expected.put("latestPercentile", "36");

--- a/src/test/java/gov/usgs/wma/statistics/control/StatsServiceTest.java
+++ b/src/test/java/gov/usgs/wma/statistics/control/StatsServiceTest.java
@@ -188,7 +188,7 @@ public class StatsServiceTest {
 	public void test_service_twoFineData() throws Exception {
 		String data = "1999/01/01,1.00\n1999/01/02,2.00";
 		
-		JsonData pojo = stats.calculate(data, MediationType.ASCENDING.toString(), SwaggerConfig.BOOLEAN_FALSE, SwaggerConfig.StatsService_PERCENTILES_DEFAULT);
+		JsonData pojo = stats.calculate(data, MediationType.ASCENDING.toString(), SwaggerConfig.BOOLEAN_FALSE, SwaggerConfig.BOOLEAN_TRUE, SwaggerConfig.StatsService_PERCENTILES_DEFAULT);
 		
 		assertTrue( pojo.isOk() );
 		assertFalse( pojo.hasErrors() );
@@ -218,7 +218,7 @@ public class StatsServiceTest {
 				"2017-06-10T04:15:00-05:00, 1.0\n"+
 				"2018-06-10T04:15:00-05:00, 1.0\n";
 		
-		JsonData pojo = stats.calculate(data, MediationType.ASCENDING.toString(), SwaggerConfig.BOOLEAN_FALSE, SwaggerConfig.StatsService_PERCENTILES_DEFAULT);
+		JsonData pojo = stats.calculate(data, MediationType.ASCENDING.toString(), SwaggerConfig.BOOLEAN_FALSE, SwaggerConfig.BOOLEAN_TRUE, SwaggerConfig.StatsService_PERCENTILES_DEFAULT);
 		assertTrue( pojo.isOk() );
 		assertFalse( pojo.hasErrors() );
 		
@@ -253,7 +253,7 @@ public class StatsServiceTest {
 				"2017-05-10T04:15:00-05:00, 1.0\n"+
 				"2018-05-10T04:15:00-05:00, 1.0\n";
 		
-		JsonData pojo = stats.calculate(data, MediationType.ASCENDING.toString(), SwaggerConfig.BOOLEAN_FALSE, SwaggerConfig.StatsService_PERCENTILES_DEFAULT);
+		JsonData pojo = stats.calculate(data, MediationType.ASCENDING.toString(), SwaggerConfig.BOOLEAN_FALSE, SwaggerConfig.BOOLEAN_TRUE, SwaggerConfig.StatsService_PERCENTILES_DEFAULT);
 		assertTrue( pojo.isOk() );
 		assertFalse( pojo.hasErrors() );
 		

--- a/src/test/java/gov/usgs/wma/statistics/logic/ValdiationMessagesTest.java
+++ b/src/test/java/gov/usgs/wma/statistics/logic/ValdiationMessagesTest.java
@@ -74,7 +74,7 @@ public class ValdiationMessagesTest {
 	
 	@Test
 	public void test_waterLevelStatistics_MONTHLY_RULE() {
-		WaterLevelStatistics stats = new WaterLevelStatistics(env, builder);
+		WaterLevelStatistics stats = new WaterLevelStatistics(env, builder, true);
 		
 		List<WLSample> samples = new LinkedList<>();
 		samples.add( createSample("2000-01-01", "1.0") );
@@ -88,7 +88,7 @@ public class ValdiationMessagesTest {
 	}
 	@Test
 	public void test_waterLevelStatistics_PROVISIONAL_RULE() {
-		WaterLevelStatistics stats = new WaterLevelStatistics(env, builder);
+		WaterLevelStatistics stats = new WaterLevelStatistics(env, builder, true);
 		
 		List<WLSample> samples = new LinkedList<>();
 		samples.add( createSample("2000-01-01", "1.0") );
@@ -103,7 +103,7 @@ public class ValdiationMessagesTest {
 	}
 	@Test
 	public void test_waterLevelStatistics_MONTLY_DETAIL_1() {
-		MonthlyStatistics<WLSample> stats = new WaterLevelStatistics(env, builder).getMonthlyStats();
+		MonthlyStatistics<WLSample> stats = new WaterLevelStatistics(env, builder, true).getMonthlyStats();
 
 		List<WLSample> samples = new LinkedList<>();
 		samples.add( createSample("2000-01-01", "1.0") );
@@ -117,7 +117,7 @@ public class ValdiationMessagesTest {
 	}
 	@Test
 	public void test_waterLevelStatistics_MONTLY_DETAIL_2() {
-		MonthlyStatistics<WLSample> stats = new WaterLevelStatistics(env, builder).getMonthlyStats();
+		MonthlyStatistics<WLSample> stats = new WaterLevelStatistics(env, builder, true).getMonthlyStats();
 
 		List<WLSample> samples = new LinkedList<>();
 		samples.add( createSample("2000-01-01", "1.0") );

--- a/src/test/java/gov/usgs/wma/statistics/model/ValdiationErrorsTest.java
+++ b/src/test/java/gov/usgs/wma/statistics/model/ValdiationErrorsTest.java
@@ -39,6 +39,7 @@ public class ValdiationErrorsTest {
 	String mediation = "AboveDatum";
 	String medians = "false";
 	String percentiles = "10, 20, 30";
+	String enforceRecent = "true";
 	
 	@Before
 	public void setup() {
@@ -49,6 +50,7 @@ public class ValdiationErrorsTest {
 		mediation = "AboveDatum";
 		medians = "false";
 		percentiles = "10, 20, 30";
+		enforceRecent = "true";
 	}
 	public String getText(String property) {
 		String text = spring.getProperty(property, SPRING_ENV_FAIL);
@@ -69,7 +71,7 @@ public class ValdiationErrorsTest {
 
 	@Test
 	public void test_statService_VALID() {
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		System.err.println(json.errors);
 		assertFalse(json.hasErrors());
 		assertTrue(json.isOk());
@@ -77,7 +79,7 @@ public class ValdiationErrorsTest {
 	@Test
 	public void test_statService_INVALID_MEDIATION() {
 		mediation = "unknown";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());
@@ -90,7 +92,7 @@ public class ValdiationErrorsTest {
 	@Test
 	public void test_statService_INVALID_MEDIANS() {
 		medians = "unknown";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());
@@ -104,7 +106,7 @@ public class ValdiationErrorsTest {
 	public void test_statService_INVALID_ROW_COLS() {
 		String badDate = "2001,01,01";
 		data = badDate + ",1.1,\n2002-02-02,2.2";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());
@@ -118,7 +120,7 @@ public class ValdiationErrorsTest {
 	public void test_statsService_INVALID_ROW_AGING() {
 		String badAging = "QZ";
 		data = "2001-01-01,1.1,"+badAging+"\n2002-02-02,2.2";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());
@@ -132,7 +134,7 @@ public class ValdiationErrorsTest {
 	public void test_statsService_INVALID_ROW_VALUE() {
 		String badValue = "QZ";
 		data = "2001-01-01,"+badValue+"\n2002-02-02,2.2";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());
@@ -151,7 +153,7 @@ public class ValdiationErrorsTest {
 	public void test_statsServcie_INVALID_ROW_DATE_BLANK() {
 		String badDate = "";
 		data = badDate + ",1.1,\n2002-02-02,2.2";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());
@@ -180,7 +182,7 @@ public class ValdiationErrorsTest {
 	public void test_statsService_INVALID_ROW_DATE_FUTURE() {
 		String badDate = "2107-01-01";
 		data = badDate + ",1.1,\n2002-02-02,2.2";
-		JsonData json = stats.calculate(builder, data, mediation, medians, percentiles);
+		JsonData json = stats.calculate(builder, data, mediation, medians, enforceRecent, percentiles);
 		
 		assertTrue(json.hasErrors());
 		assertFalse(json.isOk());


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
This is part of the work done to enable calculation of all waterlevel stats.  JIRA task: https://internal.cida.usgs.gov/jira/browse/NGWMN-1914

Description
-----------
These changes allow the stats service to interpret the enforceRecent parameter from the cache.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
