### PR TITLE
NGWMN-1932 Duplicate month intermediate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated: bypass latest percentile for months with few samples
 - Changed latest percentile to be an empty string when the month has too few values rather than null.
 - Fixed typo in "percentiles" string to "percentiles"
+- Fixed duplicated intermediate values for the current month.
 
 ### Notes
 - Releases 1.0.2 through 1.0.6 are all pipeline release build testing

--- a/boot
+++ b/boot
@@ -30,8 +30,12 @@ mkdir -p logs
 echo "Maven Building..."
 mvn package --log-file logs/mvn.log
 
+# if ! exist target/statistics.jar
+#   ln -s target/statistics*.jar target/statistics.jar
+# fi
+
 echo "Starting..."
-java -jar target/statistics-0.2.0.jar --spring.profiles.active=${1:-prod} > logs/statistics.log 2>logs/error.log &
+java -jar target/statistics.jar --spring.profiles.active=${1:-prod} > logs/statistics.log 2>logs/error.log &
 echo $! > app.pid
 
 echo "Service Started."

--- a/src/main/java/gov/usgs/wma/statistics/logic/MonthlyStatistics.java
+++ b/src/main/java/gov/usgs/wma/statistics/logic/MonthlyStatistics.java
@@ -134,7 +134,9 @@ public class MonthlyStatistics<S extends Value> extends StatisticsCalculator<S> 
 					return year.equals( Value.yearUTC(sample.time) );
 				}
 			};
-			List<S> yearSamples = samples.stream().filter(yearly).collect(Collectors.toList());
+			List<S> yearSamples = samples.stream()
+					.filter(yearly)
+					.collect(Collectors.toList());
 			BigDecimal value = valueOfPercentile( yearSamples, MEDIAN_PERCENTILE, S::valueOf);
 			monthYearlyMedians.add( new Value("",value) );
 			// remove the current year

--- a/src/main/java/gov/usgs/wma/statistics/logic/StatisticsCalculator.java
+++ b/src/main/java/gov/usgs/wma/statistics/logic/StatisticsCalculator.java
@@ -66,12 +66,12 @@ public class StatisticsCalculator<S extends Value> {
 	/**
 	 * Calculates statistics for a specifier where data must be supplied as an XML string reader.
 	 * 
-	 * This is used in the {@link DatabaseXMLCache} to supply data without requiring a unnecessary
+	 * This is used in the DatabaseXMLCache to supply data without requiring a unnecessary
 	 * read from the database. This optimization saves about 5 sec per site. This may not sound like
 	 * much; however, it only takes 3600 sites to save 5 hours!
 	 * 
 	 * @param spec the specifier only checks the agency and site. It ignores the data type.
-	 * @param reader the {@link Reader} supplying XML data samples.
+	 * @param xmlData the Reader supplying XML data samples.
 	 * @throws Exception Thrown if there is an issue parsing data from the XML reader.
 	 */
 	public JsonData calculate(Specifier spec, Reader xmlData) throws Exception {

--- a/src/main/java/gov/usgs/wma/statistics/model/JsonDataBuilder.java
+++ b/src/main/java/gov/usgs/wma/statistics/model/JsonDataBuilder.java
@@ -4,6 +4,7 @@ import static gov.usgs.wma.statistics.app.Properties.*;
 import static gov.usgs.wma.statistics.model.Value.*;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -67,16 +68,21 @@ public class JsonDataBuilder {
 	 * This is a collection of all the normalized values.
 	 * Is used for the overall percentile value.
 	 */
-	List<Value> intermediateValuesList = new LinkedList<>();
+	List<Value> intermediateValuesList   = new LinkedList<>();
+	/**
+	 * Since there are a couple places intermediate values must be calculated,
+	 * This keeps track of months that have been added to avoid duplicates.
+	 */
+	List<String> intermediateMonthsAdded = new ArrayList<String>(12);
 	/*
 	 * The string of all intermediate values to return to the requester.
 	 */
-	StringBuilder intermediateValues    = new StringBuilder();
+	StringBuilder intermediateValues     = new StringBuilder();
 	/**
 	 * This indicates weather or not to build and send the intermediate
 	 * values string back to the user.
 	 */
-	boolean includeIntermediateValues   = false;
+	boolean includeIntermediateValues    = false;
 	
 	JsonData jsonData;
 
@@ -320,6 +326,16 @@ public class JsonDataBuilder {
 	}
 	
 	public JsonDataBuilder intermediateValues(List<? extends Value> samples) {
+		if(samples == null || samples.isEmpty()) {
+			return this;
+		}
+		String month = samples.get(0).getMonth();
+		LOGGER.trace("month add request {} ", month);
+		if (this.intermediateMonthsAdded .contains(month)) {
+			return this;
+		}
+		LOGGER.trace("month add perform {}", month);
+		this.intermediateMonthsAdded.add(month);
 		this.intermediateValuesList.addAll(samples);
 		
 		if ( ! isIncludeIntermediateValues()) {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,1 +1,2 @@
-logging.level.gov.usgs DEBUG
+logging.level.gov=DEBUG
+logging.level.org.springframework=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=8777
-logging.level.gov=DEBUG
-logging.level.org.springframework==DEBUG
+logging.level.gov=INFO
+logging.level.org.springframework=INFO
 
 spring.servlet.multipart.max-request-size=20mb
 

--- a/src/test/java/gov/usgs/wma/statistics/model/JsonDataBuilderTest.java
+++ b/src/test/java/gov/usgs/wma/statistics/model/JsonDataBuilderTest.java
@@ -375,13 +375,13 @@ public class JsonDataBuilderTest {
 		assertEquals("While ensuring an emptly list to start, the size was not zero",
 				0,data.intermediateValuesList.size());
 		data.intermediateValues(values6a);
-		assertEquals("Upon added a couple new month values, the size should increase",
+		assertEquals("Upon adding a couple new month values, the size should increase",
 				2,data.intermediateValuesList.size());
 		data.intermediateValues(values7);
-		assertEquals("Upon added a couple new month values, the size should increase",
+		assertEquals("Upon adding a couple new month values, the size should increase",
 				4,data.intermediateValuesList.size());
 		data.intermediateValues(values6b);
-		assertEquals("Upon added a couple duplicate month values, the size should remain the same "
+		assertEquals("Upon adding a couple duplicate month values, the size should remain the same "
 				+ "because those values from a duplicated month should not be added multiple times",
 				4,data.intermediateValuesList.size());
 	}

--- a/src/test/java/gov/usgs/wma/statistics/model/JsonDataBuilderTest.java
+++ b/src/test/java/gov/usgs/wma/statistics/model/JsonDataBuilderTest.java
@@ -3,6 +3,7 @@ package gov.usgs.wma.statistics.model;
 import static gov.usgs.wma.statistics.model.JsonDataBuilder.*;
 import static org.junit.Assert.*;
 
+import java.awt.image.SampleModel;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -20,6 +21,8 @@ public class JsonDataBuilderTest {
 	final String VALUE_2    = "43.21";
 	final String DATE_UTC_1 = "2000-06-10T04:15:00-05:00";
 	final String DATE_UTC_2 = "2005-06-10T04:15:00-05:00";
+	final String DATE_UTC_3 = "2000-07-10T04:15:00-05:00";
+	final String DATE_UTC_4 = "2005-07-10T04:15:00-05:00";
 	final String PERCENT_1  = "24";
 	final String PERCENT_2  = "42";
 	final String MONTH_1    = "01";
@@ -28,6 +31,8 @@ public class JsonDataBuilderTest {
 	final int    COUNT      = 42;
 	final Value  SAMPLE_1   = new Value(DATE_UTC_1, VALUE_1);
 	final Value  SAMPLE_2   = new Value(DATE_UTC_2, VALUE_2);
+	final Value  SAMPLE_3   = new Value(DATE_UTC_3, VALUE_1);
+	final Value  SAMPLE_4   = new Value(DATE_UTC_4, VALUE_2);
 
 	
 	JsonDataBuilder data;
@@ -352,6 +357,33 @@ public class JsonDataBuilderTest {
 		String collection = data.jsonData.medians;
 
 		assertEquals(individuals, collection);
+	}
+	
+	@Test
+	public void test_addingIntermediateValues_uniquely() {
+		// we had a bug where the current month was added twice because of the seemingly required order of operations
+		List<Value> values6a = new ArrayList<>();
+		List<Value> values6b = new ArrayList<>();
+		List<Value> values7  = new ArrayList<>();
+		
+		values6a.add(SAMPLE_1);
+		values6a.add(SAMPLE_2);
+		values6b.addAll(values6a);
+		values7.add(SAMPLE_3);
+		values7.add(SAMPLE_4);
+		
+		assertEquals("While ensuring an emptly list to start, the size was not zero",
+				0,data.intermediateValuesList.size());
+		data.intermediateValues(values6a);
+		assertEquals("Upon added a couple new month values, the size should increase",
+				2,data.intermediateValuesList.size());
+		data.intermediateValues(values7);
+		assertEquals("Upon added a couple new month values, the size should increase",
+				4,data.intermediateValuesList.size());
+		data.intermediateValues(values6b);
+		assertEquals("Upon added a couple duplicate month values, the size should remain the same "
+				+ "because those values from a duplicated month should not be added multiple times",
+				4,data.intermediateValuesList.size());
 	}
 
 	@Test

--- a/stop
+++ b/stop
@@ -14,4 +14,4 @@ if [[ $1 = "--help" ]]; then
 fi
 
 echo "Killing old service if exists"
-ps -w -w -u `whoami` -o "pid etime ppid args" | grep aq-qualifiers | grep -v grep | cut -c1-5 | xargs kill
+ps -w -w -u `whoami` -o "pid etime ppid args" | grep statistics | grep -v grep | cut -c1-5 | xargs kill


### PR DESCRIPTION
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
NGWMN-1932 Duplicate month intermediate values

Description
-----------
Duplicate values were showing up in the intermediate values. It looked like it was just one month. It turned out to be the month of the current value. The fix was to keep track of added months and only allow a single monthly entry.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
